### PR TITLE
[impl] Add color api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,5 @@ keywords = ["display", "hex"]
 travis-ci = { repository = "tmoers/hexplay" }
 
 [dependencies]
-termion = "1"
+atty = "0.2"
+termcolor = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ keywords = ["display", "hex"]
 travis-ci = { repository = "tmoers/hexplay" }
 
 [dependencies]
+termion = "1"

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -37,5 +37,6 @@ fn main() {
         .force_color()
         .add_colors(vec![])
         .finish();
-    ascii_view.print();
+
+    color_view.print().unwrap();
 }

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -31,4 +31,11 @@ fn main() {
         .replacement_character(std::char::REPLACEMENT_CHARACTER)
         .finish();
     println!("Custom view: \n{}\n\n", combined_view);
+
+    let color_view = HexViewBuilder::new(&data)
+        .codepage(CODEPAGE_ASCII)
+        .force_color()
+        .add_colors(vec![])
+        .finish();
+    ascii_view.print();
 }

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,0 +1,104 @@
+//! Provides helpers for generating colors for use in HexViewBuilder printing,
+//! as well as some reexports of the underlying color crate, `termcolor`
+
+use std::io::{self, Write};
+use std::ops::Range;
+
+use termcolor::WriteColor;
+
+pub use termcolor::Color as Color;
+pub use termcolor::ColorSpec as Spec;
+
+/// A vector of `(ColorSpec, Range)` values to print
+pub type Colors = Vec<(Spec, Range<usize>)>;
+
+pub(crate) struct ColorlessString(pub String);
+
+impl Write for ColorlessString {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        use std::str;
+        let string = str::from_utf8(buf).unwrap();
+        self.0 += string;
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl WriteColor for ColorlessString {
+    fn supports_color(&self) -> bool {
+        false
+    }
+    fn set_color(&mut self, _spec: &Spec) -> io::Result<()> {
+        Ok(())
+    }
+    fn reset (&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+pub(crate) struct ColorRange<'a> {
+    colors: &'a Colors,
+    offset: usize,
+    idx: usize,
+}
+
+impl<'a> Clone for ColorRange<'a> {
+    fn clone(&self) -> Self {
+        ColorRange {
+            colors: self.colors,
+            offset: self.offset,
+            idx: self.idx,
+        }
+    }
+}
+
+impl<'a> ColorRange<'a> {
+    pub fn new(colors: &'a Colors) -> Self {
+        ColorRange {
+            colors: colors,
+            offset: 0,
+            idx: 0,
+        }
+    }
+    pub fn update_offset(&mut self, offset: usize) {
+        self.offset = offset;
+    }
+    pub fn get(&mut self, idx: usize) -> Option<Spec> {
+        while self.idx < self.colors.len() {
+            let (rgb, range) = self.colors[self.idx].clone();
+            let offset = self.offset + idx;
+            if offset >= range.start && offset < range.end {
+                return Some(rgb)
+            } else if offset <= range.start { // for non-contiguous colors
+                return None
+            } else {
+                self.idx += 1;
+            }
+        }
+        None
+    }
+}
+
+macro_rules! make_color {
+    ($name:ident, $name_bold:ident, $color:ident) => {
+        /// Creates the appropriate ColorSpec
+        pub fn $name() -> Spec {
+            Spec::new().set_bold(false).set_fg(Some(Color::$color)).clone()
+        }
+        /// Creates the appropriate ColorSpec, in bold
+        pub fn $name_bold () -> Spec {
+            Spec::new().set_bold(true).set_fg(Some(Color::$color)).clone()
+        }
+    }
+}
+
+make_color!(red, red_bold, Red);
+make_color!(blue, blue_bold, Blue);
+make_color!(green, green_bold, Green);
+make_color!(yellow, yellow_bold, Yellow);
+make_color!(magenta, magenta_bold, Magenta);
+make_color!(black, black_bold, Black);
+make_color!(cyan, cyan_bold, Cyan);
+make_color!(white, white_bold, White);

--- a/src/color.rs
+++ b/src/color.rs
@@ -12,7 +12,7 @@ pub use termcolor::ColorSpec as Spec;
 /// A vector of `(ColorSpec, Range)` values to print
 pub type Colors = Vec<(Spec, Range<usize>)>;
 
-pub(crate) struct ColorlessString(pub String);
+pub struct ColorlessString(pub String);
 
 impl Write for ColorlessString {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
@@ -38,7 +38,7 @@ impl WriteColor for ColorlessString {
     }
 }
 
-pub(crate) struct ColorRange<'a> {
+pub struct ColorRange<'a> {
     colors: &'a Colors,
     offset: usize,
     idx: usize,

--- a/src/format.rs
+++ b/src/format.rs
@@ -35,7 +35,7 @@ impl<'a> HexView<'a> {
         let mut buffer: Buffer = writer.buffer();
         self.fmt(&mut buffer)?;
         writer.print(&buffer)?;
-        println!();
+        println!("");
         Ok(())
     }
     /// Constructs a new HexView for the given data without offset and using codepage 850, a row width
@@ -138,7 +138,7 @@ impl<'a> HexView<'a> {
 
         while offset + (self.row_width - 1) < self.data.len() {
             let slice = &self.data[offset..offset + self.row_width];
-            writeln!(buffer)?;
+            writeln!(buffer, "")?;
             Self::fmt_line(buffer, address, &self.codepage, self.replacement_character, &slice, &mut color_range, &Padding::default())?;
             offset += self.row_width;
             address += self.row_width;
@@ -147,7 +147,7 @@ impl<'a> HexView<'a> {
 
         if end_padding != 0 {
             let slice = &self.data[offset..];
-            writeln!(buffer)?;
+            writeln!(buffer, "")?;
             Self::fmt_line(buffer, address, &self.codepage, self.replacement_character, &slice, &mut color_range, &Padding::from_right(end_padding))?;
         }
         Ok(())
@@ -413,7 +413,7 @@ mod tests {
         println!("{}", two_line_result);
 
         assert_eq!(1, one_line_result.lines().count());
-        assert_eq!(2, two_line_result.lines().count());
+        assert_eq!(3, two_line_result.lines().count());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,8 @@
 //! **NB**: overlapping color ranges have unspecified behavior (not unsafe though, of course)
 //!
 //! ```rust
+//! use hexplay::HexViewBuilder;
+//!
 //! let data : Vec<u8> = (0u8..200u8).collect();
 //!
 //! let view = HexViewBuilder::new(&data[40..72])
@@ -54,7 +56,7 @@
 //!         (hexplay::color::red(), 6..15),
 //!         (hexplay::color::blue(), 21..26),
 //!         (hexplay::color::yellow_bold(), 15..21),
-//!         (hexplay::color::gren(), 0..6),
+//!         (hexplay::color::green(), 0..6),
 //!     ])
 //!     .finish();
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,8 @@
 //! 00000040  40 41 42 43 44 45 46 47                          | @ABCDEFG         |
 //! ```
 
+extern crate termion;
+
 mod byte_mapping;
 mod format;
 
@@ -45,3 +47,5 @@ pub use byte_mapping::CODEPAGE_1252;
 pub use byte_mapping::CODEPAGE_ASCII;
 pub use format::HexView;
 pub use format::HexViewBuilder;
+pub use termion::color::Color as Color;
+pub use termion::color::Rgb as Rgb;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,16 +36,41 @@
 //! 00000030  30 31 32 33 34 35 36 37 38 39 3A 3B 3C 3D 3E 3F  | 0123456789:;<=>? |
 //! 00000040  40 41 42 43 44 45 46 47                          | @ABCDEFG         |
 //! ```
+//!
+//! # Color
+//!
+//! You can add color to the hextable by specifying a [color::Spec](color/struct.Spec.html) and a range in the hextable to color,
+//! using HexViewBuilder's [add_colors](struct.HexViewBuilder.html#method.add_colors) method.
+//!
+//! **NB**: overlapping color ranges have unspecified behavior (not unsafe though, of course)
+//!
+//! ```rust
+//! let data : Vec<u8> = (0u8..200u8).collect();
+//!
+//! let view = HexViewBuilder::new(&data[40..72])
+//!     .address_offset(40)
+//!     .row_width(16)
+//!     .add_colors(vec![
+//!         (hexplay::color::red(), 6..15),
+//!         (hexplay::color::blue(), 21..26),
+//!         (hexplay::color::yellow_bold(), 15..21),
+//!         (hexplay::color::gren(), 0..6),
+//!     ])
+//!     .finish();
+//!
+//! // this will print to stdout
+//! view.print().unwrap();
+//! ```
 
-extern crate termion;
+extern crate atty;
+extern crate termcolor;
 
 mod byte_mapping;
 mod format;
+pub mod color;
 
 pub use byte_mapping::CODEPAGE_0850;
 pub use byte_mapping::CODEPAGE_1252;
 pub use byte_mapping::CODEPAGE_ASCII;
 pub use format::HexView;
 pub use format::HexViewBuilder;
-pub use termion::color::Color as Color;
-pub use termion::color::Rgb as Rgb;


### PR DESCRIPTION
ref #4 

Adds color

![screenshot from 2017-07-25 22-27-24](https://user-images.githubusercontent.com/1920204/28605819-78840b24-7188-11e7-9957-329958526e8e.png)

The api is pretty simpl; it takes a `(termion::Rgb, Range<usize>)` in the builder.

It might be a better idea to switch to the `term` crate for more robustness, but I don't have the energy.