### PR TITLE
Fix ColorRange's `get` implementation

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -62,15 +62,13 @@ impl<'a> ColorRange<'a> {
     pub fn update_offset(&mut self, offset: usize) {
         self.offset = offset;
     }
-    pub fn get(&self, idx: usize) -> Option<Spec> {
+    pub fn get(&self, idx: usize) -> Option<&Spec> {
         let mut i = 0;
+        let offset = self.offset + idx;
         while i < self.colors.len() {
-            let (rgb, range) = self.colors[i].clone();
-            let offset = self.offset + idx;
+            let (ref rgb, ref range) = self.colors[i];
             if offset >= range.start && offset < range.end {
-                return Some(rgb)
-            } else if offset <= range.start { // for non-contiguous colors
-                return None
+                return Some(rgb);
             } else {
                 i += 1;
             }

--- a/src/format.rs
+++ b/src/format.rs
@@ -185,7 +185,7 @@ impl Padding {
     }
 }
 
-fn fmt_bytes_as_hex<W: WriteColor>(f: &mut W, bytes: &[u8], color_range: &mut ColorRange, padding: &Padding) -> io::Result<()> {
+fn fmt_bytes_as_hex<W: WriteColor>(f: &mut W, bytes: &[u8], color_range: &ColorRange, padding: &Padding) -> io::Result<()> {
     let mut separator = "";
 
     for _ in 0..padding.left {
@@ -212,7 +212,7 @@ fn fmt_bytes_as_hex<W: WriteColor>(f: &mut W, bytes: &[u8], color_range: &mut Co
     Ok(())
 }
 
-fn fmt_bytes_as_char<W: WriteColor>(f: &mut W, cp: &[char], repl_char: char, bytes: &[u8], color_range: &mut ColorRange, padding: &Padding) -> io::Result<()> {
+fn fmt_bytes_as_char<W: WriteColor>(f: &mut W, cp: &[char], repl_char: char, bytes: &[u8], color_range: &ColorRange, padding: &Padding) -> io::Result<()> {
     for _ in 0..padding.left {
         write!(f, " ")?;
     }
@@ -237,13 +237,12 @@ fn fmt_bytes_as_char<W: WriteColor>(f: &mut W, cp: &[char], repl_char: char, byt
 fn fmt_line<W: WriteColor>(f: &mut W, address: usize, cp: &[char], repl_char: char, bytes: &[u8], color_range: &mut ColorRange, padding: &Padding) -> io::Result<()> {
     write!(f, "{:0width$X}", address, width = 8)?;
 
-    let mut cr = color_range.clone();
     write!(f, "  ")?;
-    fmt_bytes_as_hex(f, bytes, &mut cr, &padding)?;
+    fmt_bytes_as_hex(f, bytes, &color_range, &padding)?;
     write!(f, "  ")?;
 
     write!(f, "| ")?;
-    fmt_bytes_as_char(f, cp, repl_char, bytes, &mut cr, &padding)?;
+    fmt_bytes_as_char(f, cp, repl_char, bytes, &color_range, &padding)?;
     write!(f, " |")?;
 
     Ok(())


### PR DESCRIPTION
Fixes #6.

Before:

![image](https://user-images.githubusercontent.com/658538/39785954-7654e762-52db-11e8-8820-22bcb4960b1d.png)

After:

![image](https://user-images.githubusercontent.com/658538/39786011-c8ba6982-52db-11e8-8ed3-19b5db34fa07.png)